### PR TITLE
Added raw item interface to query results

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -113,6 +113,7 @@ type Entry struct {
 	Expiration time.Time // Entry expiration timestamp if requested and supported (see TTLDatastore).
 	Size       int       // Might be -1 if the datastore doesn't support listing the size with KeysOnly
 	//                   // or if ReturnsSizes is not set
+	Raw interface{}
 }
 
 // Result is a special entry that includes an error, so that the client


### PR DESCRIPTION
Added a quick generic field to the result entry struct, so we can plug in datastore dependant types/information. We can prob change the name here but this is a quick fix